### PR TITLE
Add Terraform provider configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Terraform state and directories
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.58.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:lrsaLnbjGJ/XzfYHKxkXzJIYukLDdlVt9PpLiqtPgog=",
+    "zh:00085323b68a18a66bfcddd077dd88f6d632e74829100b82a77628379bea8b86",
+    "zh:1b254bc4b52e2d433250109b1a55a1d304abbc0274c6f548ea19a775edf335a4",
+    "zh:2721c7a95983f9028dfc44af5fb84eb4b06547bd69ca268290867c6f786af134",
+    "zh:3eaf9a811a39b32b0ea60244f0fbf0cd4f3957dcf5b4b4dcedfb5932763c11e3",
+    "zh:5b0887238097356ce7b59b87dd8eb98679466f488fbf0447e47030890f6723c1",
+    "zh:701e21cd77a6360369c186f17b003f4f41ed482c7001045da7908806ffa8a2c1",
+    "zh:8cb9a97f20629d5a9eafaaa4cfeb31c0a7f11ebff22c966e83884327f5cfae3d",
+    "zh:90536838216be14640665bc87731b38c8ea147ee0b7d3a8600197abff1fb20e1",
+    "zh:91bed285637508b656cdadf208a6204dba9205d79227dff24d475d782c2eb2d6",
+    "zh:a3589e7e3d190addacd9cddb963ff0d3860901465e62eb2ebdcbfa90224c4ff6",
+    "zh:a963feef59258257117e95c53eabccbbbd1c4fad417db7e1b47747da617db173",
+    "zh:c2adc5035935ddc35482dc8cae00de4aa0ddbae8c2503e43d5a94dd0003741f2",
+    "zh:c731c8da60bf5c2ed7367b2558f8a979579caf0df878b0326743ec12fdfc7b7f",
+    "zh:d31ea103173832e4e5404347d1748ceff2940f0429c31bfb65d3daf4dd2e44dd",
+    "zh:f1ba5706104a0fa29e981f2f25acb63b6d71dac5cdb31ee54f283a1ba2e13853",
+    "zh:f99ffe3dad8e87cb7d1233d11894714d250e9339bbd546096c7d1673eec305df",
+  ]
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+variable "do_token" {
+  description = "DigitalOcean API token"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- add DigitalOcean provider configuration
- add Terraform lock file
- ignore Terraform state files and directories

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6868a63675c48331b43af62472b1c1df